### PR TITLE
Improve templates and NetworkProvider

### DIFF
--- a/src/cli/create.ts
+++ b/src/cli/create.ts
@@ -88,4 +88,8 @@ export const create: Runner = async (args: Args) => {
     await createFile(TESTS_DIR, name + '.spec.ts', prefix + 'test.spec.ts.template', replaces);
 
     await createFile(SCRIPTS_DIR, 'deploy' + name + '.ts', prefix + 'deploy.ts.template', replaces);
+
+    if (which === 'counter') {
+        await createFile(SCRIPTS_DIR, 'increment' + name + '.ts', 'counter.increment.ts.template', replaces);
+    }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { tonDeepLink } from './utils';
+export { tonDeepLink, sleep } from './utils';
 
 export { NetworkProvider } from './network/NetworkProvider';
 

--- a/src/network/NetworkProvider.ts
+++ b/src/network/NetworkProvider.ts
@@ -6,7 +6,8 @@ export interface NetworkProvider {
     network(): 'mainnet' | 'testnet';
     sender(): Sender;
     api(): TonClient;
-    provider(addr: Address): ContractProvider;
+    provider(address: Address, init?: { code?: Cell; data?: Cell }): ContractProvider;
+    isContractDeployed(address: Address): Promise<boolean>;
     waitForDeploy(address: Address, attempts?: number, sleepDuration?: number): Promise<void>;
     /**
      * @deprecated

--- a/src/network/createNetworkProvider.ts
+++ b/src/network/createNetworkProvider.ts
@@ -132,12 +132,16 @@ class NetworkProviderImpl implements NetworkProvider {
         return this.#tc;
     }
 
-    provider(addr: Address, init?: { code?: Cell; data?: Cell }): ContractProvider {
+    provider(address: Address, init?: { code?: Cell; data?: Cell }): ContractProvider {
         return new WrappedContractProvider(
-            addr,
-            this.#tc.provider(addr, init ? { code: init.code ?? null, data: init.data ?? null } : null),
+            address,
+            this.#tc.provider(address, init ? { code: init.code ?? null, data: init.data ?? null } : null),
             init
         );
+    }
+
+    isContractDeployed(address: Address): Promise<boolean> {
+        return this.#tc.isContractDeployed(address);
     }
 
     async waitForDeploy(address: Address, attempts: number = 10, sleepDuration: number = 2000) {
@@ -147,10 +151,10 @@ class NetworkProviderImpl implements NetworkProvider {
 
         for (let i = 1; i <= attempts; i++) {
             this.#ui.setActionPrompt(`Awaiting contract deployment... [Attempt ${i}/${attempts}]`);
-            const isDeployed = await this.#tc.isContractDeployed(address);
+            const isDeployed = await this.isContractDeployed(address);
             if (isDeployed) {
                 this.#ui.clearActionPrompt();
-                this.#ui.write('Contract deployed!');
+                this.#ui.write(`Contract deployed at address ${address.toString()}`);
                 this.#ui.write(
                     `You can view it at https://${
                         this.#network === 'testnet' ? 'testnet.' : ''
@@ -171,7 +175,7 @@ class NetworkProviderImpl implements NetworkProvider {
      * Use your Contract's `sendDeploy` method (or similar) together with `waitForDeploy` instead.
      */
     async deploy(contract: Contract, value: bigint, body?: Cell, waitAttempts: number = 10) {
-        const isDeployed = await this.#tc.isContractDeployed(contract.address);
+        const isDeployed = await this.isContractDeployed(contract.address);
         if (isDeployed) {
             throw new Error('Contract is already deployed!');
         }

--- a/src/network/send/TonConnectProvider.ts
+++ b/src/network/send/TonConnectProvider.ts
@@ -107,6 +107,7 @@ export class TonConnectProvider implements SendProvider {
             ],
         });
 
+        this.#ui.clearActionPrompt();
         this.#ui.write('Sent transaction');
     }
 }

--- a/src/templates/counter.deploy.ts.template
+++ b/src/templates/counter.deploy.ts.template
@@ -3,17 +3,19 @@ import { {{name}} } from '../wrappers/{{name}}';
 import { compile, NetworkProvider } from '@ton-community/blueprint';
 
 export async function run(provider: NetworkProvider) {
-    const {{loweredName}} = {{name}}.createFromConfig(
-        {
-            id: Math.floor(Math.random() * 10000),
-            counter: 0,
-        },
-        await compile('{{name}}')
+    const {{loweredName}} = provider.open(
+        {{name}}.createFromConfig(
+            {
+                id: Math.floor(Math.random() * 10000),
+                counter: 0,
+            },
+            await compile('{{name}}')
+        )
     );
 
-    await provider.deploy({{loweredName}}, toNano('0.05'));
+    await {{loweredName}}.sendDeploy(provider.sender(), toNano('0.05'));
 
-    const openedContract = provider.open({{loweredName}});
+    await provider.waitForDeploy({{loweredName}}.address);
 
-    console.log('ID', await openedContract.getID());
+    console.log('ID', await {{loweredName}}.getID());
 }

--- a/src/templates/counter.increment.ts.template
+++ b/src/templates/counter.increment.ts.template
@@ -1,0 +1,37 @@
+import { Address, toNano } from 'ton-core';
+import { {{name}} } from '../wrappers/{{name}}';
+import { NetworkProvider, sleep } from '@ton-community/blueprint';
+
+export async function run(provider: NetworkProvider, args: string[]) {
+    const ui = provider.ui();
+
+    const address = Address.parse(args.length > 0 ? args[0] : await ui.input('{{name}} address'));
+
+    if (!(await provider.isContractDeployed(address))) {
+        ui.write(`Error: Contract at address ${address} is not deployed!`);
+        return;
+    }
+
+    const {{loweredName}} = provider.open({{name}}.createFromAddress(address));
+
+    const counterBefore = await {{loweredName}}.getCounter();
+
+    await {{loweredName}}.sendIncrease(provider.sender(), {
+        increaseBy: 1,
+        value: toNano('0.05'),
+    });
+
+    ui.write('Waiting for counter to increase...');
+
+    let counterAfter = await {{loweredName}}.getCounter();
+    let attempt = 1;
+    while (counterAfter === counterBefore) {
+        ui.setActionPrompt(`Attempt ${attempt}`);
+        await sleep(2000);
+        counterAfter = await {{loweredName}}.getCounter();
+        attempt++;
+    }
+
+    ui.clearActionPrompt();
+    ui.write('Counter increased successfully!');
+}

--- a/src/templates/deploy.ts.template
+++ b/src/templates/deploy.ts.template
@@ -3,11 +3,11 @@ import { {{name}} } from '../wrappers/{{name}}';
 import { compile, NetworkProvider } from '@ton-community/blueprint';
 
 export async function run(provider: NetworkProvider) {
-    const {{loweredName}} = {{name}}.createFromConfig({}, await compile('{{name}}'));
+    const {{loweredName}} = provider.open({{name}}.createFromConfig({}, await compile('{{name}}')));
 
-    await provider.deploy({{loweredName}}, toNano('0.05'));
+    await {{loweredName}}.sendDeploy(provider.sender(), toNano('0.05'));
 
-    const openedContract = provider.open({{loweredName}});
+    await provider.waitForDeploy({{loweredName}}.address);
 
-    // run methods on `openedContract`
+    // run methods on `{{loweredName}}`
 }


### PR DESCRIPTION
Specifically, this adds a new script to the counter template that is meant to increment said counter. Also now uses the `open` method from `NetworkProvider` to work with contracts, including deploy.