### PR TITLE
Feature: explorer selector for the deployed contract

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -94,3 +94,24 @@ export async function selectFile(
         module: opts.import !== false ? await import(selected.path) : undefined,
     };
 }
+
+export function getExplorerLink(address: string, network: string, explorer: string) {
+    const networkPrefix = network === 'testnet' ? 'testnet.' : ''
+
+    switch (explorer) {
+        case 'tonscan':
+            return `https://${networkPrefix}tonscan.org/address/${address}`;
+
+        case 'tonapi':
+            return `https://${networkPrefix}tonapi.io/account/${address}`;
+
+        case 'toncx':
+            return `https://${networkPrefix}ton.cx/address/${address}`;
+
+        case 'dton':
+            return `https://${networkPrefix}dton.io/a/${address}`;
+
+        default:
+            return `https://${networkPrefix}tonscan.org/address/${address}`;
+    }
+}


### PR DESCRIPTION
Added 3 more explorers to select from when the contract is successfully deployed. The default one lacks some features from other explorers, and vice versa, so now there are 4 of them to choose from, for example ton.cx is very useful if you want to call get_methods of your contract right away.