### PR TITLE
Fix: ton-core typos

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@types/qrcode-terminal": "^0.12.0",
         "prettier": "^2.8.3",
         "ton": "^13.3.0",
-        "ton-core": "^0.46.0",
+        "ton-core": "^0.48.0",
         "typescript": "^4.9.4"
     },
     "peerDependencies": {

--- a/src/network/createNetworkProvider.ts
+++ b/src/network/createNetworkProvider.ts
@@ -56,8 +56,8 @@ class SendProviderSender implements Sender {
             console.warn('To silence this warning, change your `bounce` flags passed to Senders to unset or undefined');
         }
 
-        if (!(args.sendMode === undefined || args.sendMode == SendMode.PAY_GAS_SEPARATLY)) {
-            throw new Error('Deployer sender does not support `sendMode` other than `PAY_GAS_SEPARATLY`');
+        if (!(args.sendMode === undefined || args.sendMode == SendMode.PAY_GAS_SEPARATELY)) {
+            throw new Error('Deployer sender does not support `sendMode` other than `PAY_GAS_SEPARATELY`');
         }
 
         await this.#provider.sendTransaction(args.to, args.value, args.body ?? undefined, args.init ?? undefined);

--- a/src/templates/counter.wrapper.ts.template
+++ b/src/templates/counter.wrapper.ts.template
@@ -29,7 +29,7 @@ export class {{name}} implements Contract {
     async sendDeploy(provider: ContractProvider, via: Sender, value: bigint) {
         await provider.internal(via, {
             value,
-            sendMode: SendMode.PAY_GAS_SEPARATLY,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
             body: beginCell().endCell(),
         });
     }
@@ -45,7 +45,7 @@ export class {{name}} implements Contract {
     ) {
         await provider.internal(via, {
             value: opts.value,
-            sendMode: SendMode.PAY_GAS_SEPARATLY,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
             body: beginCell()
                 .storeUint(Opcodes.increase, 32)
                 .storeUint(opts.queryID ?? 0, 64)

--- a/src/templates/wrapper.ts.template
+++ b/src/templates/wrapper.ts.template
@@ -22,7 +22,7 @@ export class {{name}} implements Contract {
     async sendDeploy(provider: ContractProvider, via: Sender, value: bigint) {
         await provider.internal(via, {
             value,
-            sendMode: SendMode.PAY_GAS_SEPARATLY,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
             body: beginCell().endCell(),
         });
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -644,10 +644,10 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
-ton-core@^0.46.0:
-  version "0.46.0"
-  resolved "https://registry.yarnpkg.com/ton-core/-/ton-core-0.46.0.tgz#4138606fccf7fa45dc5c6cd6dcf1d1f17b2d4215"
-  integrity sha512-QUOlL98652rsOPTIvB01+MsAgLI1ehvpsngYzNWr7pxHOk4xk64Adq0StTmqGEchkzjhNowIo3gzwGGPrxo3zw==
+ton-core@^0.48.0:
+  version "0.48.0"
+  resolved "https://registry.yarnpkg.com/ton-core/-/ton-core-0.48.0.tgz#df744c9b13b3193cb7eb8a9cbb715bcf0437e467"
+  integrity sha512-v3QL0CC8iQQ0cjUN0lI9hK7wEpLW2Wnm+N5Ukm+NSbtQ0vq36LGQR/BRywoOQZJm59XzmW4ATbtCWeas9ePrRA==
   dependencies:
     symbol.inspect "1.0.1"
 


### PR DESCRIPTION
`ton-core` lower than `0.48.0` had several typos in `SendMode`. This PR upgrades `ton-core` to `0.48.0` and fixes the typos in templates.