### PR TITLE
Add walletId when using mnemonic provider

### DIFF
--- a/src/cli/create.ts
+++ b/src/cli/create.ts
@@ -85,7 +85,7 @@ export const create: Runner = async (args: Args, ui: UIProvider) => {
         name,
         loweredName: name.substring(0, 1).toLowerCase() + name.substring(1),
         snakeName,
-        contractPath: 'contracts/' + snakeName + '.' + (lang === 'func' ? 'fc' : (lang === 'tolk' ? 'tolk' : 'tact')),
+        contractPath: 'contracts/' + snakeName + '.' + (lang === 'func' ? 'fc' : lang === 'tolk' ? 'tolk' : 'tact'),
     };
 
     const config = await getConfig();

--- a/src/cli/set.ts
+++ b/src/cli/set.ts
@@ -19,7 +19,7 @@ const getVersions = (pkg: string, ui: UIProvider): Promise<string[]> => {
                         if (Array.isArray(resJson)) {
                             resolve(resJson);
                         } else {
-                            reject(new TypeError("Expect json array on stdout, but got:\n" + stdout));
+                            reject(new TypeError('Expect json array on stdout, but got:\n' + stdout));
                         }
                     } catch (e) {
                         reject(e);
@@ -30,7 +30,7 @@ const getVersions = (pkg: string, ui: UIProvider): Promise<string[]> => {
                 }
             }
             if (error) {
-                ui.write("Failed to get func-js-bin package versions!");
+                ui.write('Failed to get func-js-bin package versions!');
                 reject(error);
             }
         });
@@ -40,20 +40,20 @@ const getVersions = (pkg: string, ui: UIProvider): Promise<string[]> => {
 const install = (cmd: string, ui: UIProvider): Promise<void> => {
     return new Promise((resolve, reject) => {
         exec(cmd, (error, stdout, stderr) => {
-                if (stderr) {
-                    ui.write(stderr);
-                }
-                if (stdout) {
-                    ui.write(stdout);
-                }
-                if (error) {
-                    reject(error);
-                    return;
-                }
-                resolve();
+            if (stderr) {
+                ui.write(stderr);
+            }
+            if (stdout) {
+                ui.write(stdout);
+            }
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve();
         });
     });
-}
+};
 
 export const set: Runner = async (args: Args, ui: UIProvider) => {
     const localArgs = arg(helpArgs);
@@ -81,10 +81,16 @@ export const set: Runner = async (args: Args, ui: UIProvider) => {
             const packageContents = (await readFile(packagePath)).toString('utf-8');
             const parsedPackage = JSON.parse(packageContents);
 
-            const packageManager: 'npm' | 'yarn' | 'pnpm' | 'other' = await ui.choose('Choose your package manager', ['npm', 'yarn', 'pnpm', 'other'], (s) => s);
+            const packageManager: 'npm' | 'yarn' | 'pnpm' | 'other' = await ui.choose(
+                'Choose your package manager',
+                ['npm', 'yarn', 'pnpm', 'other'],
+                (s) => s,
+            );
 
             if (packageManager === 'other') {
-                ui.write(`Please find out how to override @ton-community/func-js-bin version to ${version} using your package manager, do that, and then install the packages`);
+                ui.write(
+                    `Please find out how to override @ton-community/func-js-bin version to ${version} using your package manager, do that, and then install the packages`,
+                );
                 return;
             }
 

--- a/src/cli/verify.ts
+++ b/src/cli/verify.ts
@@ -288,7 +288,7 @@ export const verify: Runner = async (args: Args, ui: UIProvider, context: Runner
 
     const backend = backends[network];
 
-    const sourceRegistry   = networkProvider.open(new SourceRegistry(backend.sourceRegistry));
+    const sourceRegistry = networkProvider.open(new SourceRegistry(backend.sourceRegistry));
     const verifierRegistry = networkProvider.open(new VerifierRegistry(await sourceRegistry.getVerifierRegistry()));
 
     const verifier = (await verifierRegistry.getVerifiers()).find((v) => v.name === backend.id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,15 @@ export { NetworkProvider } from './network/NetworkProvider';
 
 export { createNetworkProvider } from './network/createNetworkProvider';
 
-export { compile, CompileOpts, SourceSnapshot, TolkCompileResult, FuncCompileResult, TactCompileResult, CompileResult } from './compile/compile';
+export {
+    compile,
+    CompileOpts,
+    SourceSnapshot,
+    TolkCompileResult,
+    FuncCompileResult,
+    TactCompileResult,
+    CompileResult,
+} from './compile/compile';
 
 export { CompilerConfig, HookParams } from './compile/CompilerConfig';
 

--- a/src/network/send/DeeplinkProvider.ts
+++ b/src/network/send/DeeplinkProvider.ts
@@ -36,7 +36,9 @@ export class DeeplinkProvider implements SendProvider {
             this.#ui.write('\n');
 
             if (err instanceof Error && err.message.includes('code length overflow')) {
-                this.#ui.write('Message is too large to be sent via QR code. Please use the ton:// link or another method.');
+                this.#ui.write(
+                    'Message is too large to be sent via QR code. Please use the ton:// link or another method.',
+                );
                 process.exit(1);
             }
             throw err;

--- a/src/network/send/MnemonicProvider.ts
+++ b/src/network/send/MnemonicProvider.ts
@@ -41,10 +41,14 @@ interface WalletInstance extends Contract {
 }
 
 interface WalletClass {
-    create(args: { workchain: number; publicKey: Buffer }): WalletInstance;
+    create(args: { workchain?: number; publicKey: Buffer; walletId?: any }): WalletInstance;
 }
 
 export type WalletVersion = 'v1r1' | 'v1r2' | 'v1r3' | 'v2r1' | 'v2r2' | 'v3r1' | 'v3r2' | 'v4' | 'v5r1';
+
+export type WalletId = {
+    networkGlobalId: number;
+} | number | null | undefined;
 
 const wallets: Record<WalletVersion, WalletClass> = {
     v1r1: WalletContractV1R1,
@@ -70,6 +74,7 @@ export class MnemonicProvider implements SendProvider {
         secretKey: Buffer;
         client: BlueprintTonClient;
         ui: UIProvider;
+        walletId?: WalletId;
     }) {
         if (!(params.version in wallets)) {
             throw new Error(`Unknown wallet version ${params.version}`);
@@ -81,6 +86,7 @@ export class MnemonicProvider implements SendProvider {
             wallets[params.version].create({
                 workchain: params.workchain ?? 0,
                 publicKey: kp.publicKey,
+                walletId: params.walletId,
             }),
             (params) =>
                 this.#client.provider(

--- a/src/network/send/TonConnectProvider.ts
+++ b/src/network/send/TonConnectProvider.ts
@@ -34,8 +34,7 @@ export class TonConnectProvider implements SendProvider {
     constructor(storage: Storage, ui: UIProvider) {
         this.#connector = new TonConnect({
             storage: new TonConnectStorage(storage),
-            manifestUrl:
-                'https://raw.githubusercontent.com/ton-org/blueprint/main/tonconnect/manifest.json',
+            manifestUrl: 'https://raw.githubusercontent.com/ton-org/blueprint/main/tonconnect/manifest.json',
         });
         this.#ui = ui;
     }

--- a/src/utils/selection.utils.ts
+++ b/src/utils/selection.utils.ts
@@ -6,7 +6,7 @@ import { COMPILE_END, getCompilablesDirectory } from '../compile/compile';
 import { File } from '../types/file';
 
 export const findCompiles = async (directory?: string): Promise<File[]> => {
-    const dir = directory ?? await getCompilablesDirectory();
+    const dir = directory ?? (await getCompilablesDirectory());
     const files = await fs.readdir(dir);
     const compilables = files.filter((file) => file.endsWith(COMPILE_END));
     return compilables.map((file) => ({
@@ -21,7 +21,7 @@ export const findScripts = async (): Promise<File[]> => {
 
     return scripts
         .map((script) => ({
-            name: path.join(script.path.slice(SCRIPTS_DIR.length+1), path.parse(script.name).name),
+            name: path.join(script.path.slice(SCRIPTS_DIR.length + 1), path.parse(script.name).name),
             path: path.join(script.path, script.name),
         }))
         .sort((a, b) => (a.name >= b.name ? 1 : -1));


### PR DESCRIPTION
Fix #116 

When I use mnemonic provider with Wallet v5r1, I couldn't use the testnet wallet because of missing `networkGlobalId` in `walletId` option.

**Added**
- `WALLET_NETWORK_GLOBAL_ID` environment variable to set `networkGlobalId` when `custom` network is used.

**Changed**
- Some files were changed after running `yarn format`