### PR TITLE
feat: Output library boc separately from raw code.

### DIFF
--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -130,6 +130,12 @@ export async function getCompilerOptions(config: CompilerConfig): Promise<{
     };
 }
 
+export function libraryCellFromCode(code: Cell) {
+    // Pack resulting code hash into library cell
+    const libPrep = beginCell().storeUint(2, 8).storeBuffer(code.hash()).endCell();
+    return new Cell({ exotic: true, bits: libPrep.bits, refs: libPrep.refs });
+}
+
 export async function doCompile(name: string, opts?: CompileOpts): Promise<CompileResult> {
     const config = await getCompilerConfigForContract(name);
 
@@ -154,9 +160,7 @@ export async function doCompile(name: string, opts?: CompileOpts): Promise<Compi
     const buildLibrary = opts?.buildLibrary ?? ('buildLibrary' in config && config.buildLibrary === true);
 
     if (buildLibrary) {
-        // Pack resulting code hash into library cell
-        const libPrep = beginCell().storeUint(2, 8).storeBuffer(res.code.hash()).endCell();
-        res.code = new Cell({ exotic: true, bits: libPrep.bits, refs: libPrep.refs });
+        res.code = libraryCellFromCode(res.code);
     }
 
     return res;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export {
     FuncCompileResult,
     TactCompileResult,
     CompileResult,
+    libraryCellFromCode,
 } from './compile/compile';
 
 export { CompilerConfig, HookParams } from './compile/CompilerConfig';


### PR DESCRIPTION
# Build output
Before, if `buildLibrary` parameter in `CompilerConfig` was set to true, only library hash and boc ended up into blueprint build output.

This commit adds additional attributes to the build outputs:

- libraryHash
- libraryBoc

While always keeping the raw code hash and boc present.

## Before
Only library data
``` json
{
  "hash": "89468f02c78e570802e39979c8516fc38df07ea76a48357e0536f2ba7b3ee37b",
  "hashBase64": "iUaPAseOVwgC45l5yFFvw43wfqdqSDV+BTbyuns+43s=",
  "hex": "b5ee9c72410101010023000842028f452d7a4dfd74066b682365177259ed05734435be76b5fd4bd5d8af2b7c3d68206bbf76"
}
```

## After

``` json
{
  "hash": "8f452d7a4dfd74066b682365177259ed05734435be76b5fd4bd5d8af2b7c3d68",
  "hashBase64": "j0Utek39dAZraCNlF3JZ7QVzRDW+drX9S9XYryt8PWg=",
  "hex": "b5ee9c7241020f010003d1000114ff00f4a413f4bcf2c80b01020162020c02f8d001d0d3030171b08e48135f038020d721ed44d0d303fa00fa40fa40d104d31f01840f218210178d4519ba0282107bdd97deba12b1f2f48040d721fa003012a0401303c8cb0358fa0201cf1601cf16c9ed54e0fa40fa4031fa0031f401fa0031fa00013170f83a02d31f012082100f8a7ea5ba8e85303459db3ce033030601f203d33f0101fa00fa4021fa4430c000f2e14ded44d0d303fa00fa40fa40d15309c7052471b0c00021b1f2ad522bc705500ab1f2e0495115a120c2fff2aff82a54259070546004131503c8cb0358fa0201cf1601cf16c921c8cb0113f40012f400cb00c920f9007074c8cb02ca07cbffc9d004fa40f401fa002004019820d70b009ad74bc00101c001b0f2b19130e2c88210178d451901cb1f500a01cb3f5008fa0223cf1601cf1626fa025007cf16c9c8801801cb055004cf1670fa024063775003cb6bccccc945370500b42191729171e2f839206e938124279120e2216e94318128739101e25023a813a0738103a370f83ca00270f83612a00170f836a07381040982100966018070f837a0bcf2b0048050fb005803c8cb0358fa0201cf1601cf16c9ed5402d0228210178d4519ba8e84325adb3ce034218210595f07bcba8e843101db3ce032208210eed236d3ba8e2f30018040d721d303d1ed44d0d303fa00fa40fa40d1335142c705f2e04a403303c8cb0358fa0201cf1601cf16c9ed54e06c218210d372158cbadc840ff2f0070a03f4ed44d0d303fa00fa40fa40d12372b0c002f26d07d33f0101fa005141a004fa40fa4053bac705f82a5464e070546004131503c8cb0358fa0201cf1601cf16c921c8cb0113f40012f400cb00c9f9007074c8cb02ca07cbffc9d0500cc7051bb1f2e04a09fa0021925f04e30d26d70b01c000b393306c33e30d550208090b0060c882107362d09c01cb1f2501cb3f5004fa0258cf1658cf16c9c8801001cb0524cf1658fa02017158cb6accc98011fb00007a5054a1f82fa07381040982100966018070f837b60972fb02c8801001cb055005cf1670fa027001cb6a8210d53276db01cb1f5801cb3fc9810082fb005901f2ed44d0d303fa00fa40fa40d106d33f0101fa00fa40f401d15141a15288c705f2e04926c2fff2afc882107bdd97de01cb1f5801cb3f01fa0221cf1658cf16c9c8801801cb0526cf1670fa02017158cb6accc903f839206e943081169fde718102f270f8380170f836a0811a7770f836a0bcf2b0028050fb00030b002003c8cb0358fa0201cf1601cf16c9ed540201200d0e0027bfd8176a2686981fd007d207d206899fc15209840021bc508f6a2686981fd007d207d2068af81c31b8493c",
  "libraryHash": "89468f02c78e570802e39979c8516fc38df07ea76a48357e0536f2ba7b3ee37b",
  "libraryBoc": "b5ee9c72410101010023000842028f452d7a4dfd74066b682365177259ed05734435be76b5fd4bd5d8af2b7c3d68206bbf76"
}
```



## Checklist

Please ensure the following items are completed before requesting review:

* [ ] Updated `CHANGELOG.md` with relevant changes
* [ ] Documented the contribution in `README.md`
* [ ] Added tests to demonstrate correct behavior (both positive and negative cases)
* [ x] All tests pass successfully (`yarn test`)
* [x ] Code passes linting checks (`yarn lint`)
