### PR TITLE
fix: fix `slice_compute_data_size?` parameter type in stdlib.fc

### DIFF
--- a/src/templates/func/common/contracts/imports/stdlib.fc.template
+++ b/src/templates/func/common/contracts/imports/stdlib.fc.template
@@ -198,7 +198,7 @@ int check_data_signature(slice data, slice signature, int public_key) asm "CHKSI
 (int, int, int, int) compute_data_size?(cell c, int max_cells) asm "CDATASIZEQ NULLSWAPIFNOT2 NULLSWAPIFNOT";
 
 ;;; A non-quiet version of [slice_compute_data_size?] that throws a cell overflow exception (8) on failure.
-(int, int, int, int) slice_compute_data_size?(cell c, int max_cells) asm "SDATASIZEQ NULLSWAPIFNOT2 NULLSWAPIFNOT";
+(int, int, int, int) slice_compute_data_size?(slice s, int max_cells) asm "SDATASIZEQ NULLSWAPIFNOT2 NULLSWAPIFNOT";
 
 ;;; Throws an exception with exit_code excno if cond is not 0 (commented since implemented in compilator)
 ;; () throw_if(int excno, int cond) impure asm "THROWARGIF";


### PR DESCRIPTION
Corrects the function signature of slice_compute_data_size? in stdlib.fc. The function was incorrectly declared with a `cell` parameter, while the underlying SDATASIZEQ instruction operates on a `slice`. This change updates the parameter type to `slice` to match actual usage and prevent type errors.

## Issue

Closes #<issue-number>

## Checklist

Please ensure the following items are completed before requesting review:

* [ ] Updated `CHANGELOG.md` with relevant changes
* [ ] Documented the contribution in `README.md`
* [ ] Added tests to demonstrate correct behavior (both positive and negative cases)
* [ ] All tests pass successfully (`yarn test`)
* [ ] Code passes linting checks (`yarn lint`)
