### PR TITLE
docs: add common pitfalls section clarifying @ton/core vs @ton/ton imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,3 +370,28 @@ MIT
 ## Donations
 
 TON - `EQAQR1d1Q4NaE5EefwUMdrr1QvXg-8mDB0XI2-fwDBD0nYxC`
+
+## Common pitfalls
+
+### Package imports: @ton/core vs @ton/ton
+
+A frequent source of confusion when developing with Blueprint is which package provides which utility. Here is a quick reference:
+
+| Utility | Correct import |
+|---|---|
+| `Cell`, `beginCell`, `Address`, `toNano` | `@ton/core` |
+| `internal()` message creator | `@ton/core` |
+| `WalletContractV4`, `TonClient` | `@ton/ton` |
+| `mnemonicNew`, `mnemonicToWalletKey` | `@ton/crypto` |
+
+```typescript
+// ✅ Correct
+import { internal, Cell, toNano, Address } from '@ton/core';
+import { WalletContractV4 } from '@ton/ton';
+import { mnemonicNew } from '@ton/crypto';
+
+// ❌ Wrong — internal() does not exist in @ton/ton
+import { internal } from '@ton/ton';
+```
+
+> **Note:** `@ton/ton` depends on and re-exports many things from `@ton/core`, but message creation utilities like `internal()` must be imported from `@ton/core` directly.


### PR DESCRIPTION
## What

Adds a **Common pitfalls** section to the README documenting the correct import packages for TON utilities.

## Why

A very common source of confusion for developers starting with Blueprint is knowing which package exports which utility. In particular, `internal()` (for creating internal messages) must be imported from `@ton/core`, not `@ton/ton` — but this is not documented anywhere.

This causes silent runtime failures (`TypeError: internal is not a function`) that are hard to debug.

## Changes

- Added `## Common pitfalls` section at the end of README.md
- Includes a quick-reference table: `@ton/core` vs `@ton/ton` vs `@ton/crypto`
- Includes ✅ correct and ❌ wrong code examples

## Context

Found this issue while building [TON Agent Platform](https://github.com/spendollars/TonAgentPlatform), an open-source no-code AI agent platform on TON. Also opened a related issue in ton-org/ton-core: https://github.com/ton-org/ton-core/issues/145