### PR TITLE
Revert "fix: fix `slice_compute_data_size?` parameter type in stdlib.fc"

### DIFF
--- a/src/templates/func/common/contracts/imports/stdlib.fc.template
+++ b/src/templates/func/common/contracts/imports/stdlib.fc.template
@@ -198,7 +198,7 @@ int check_data_signature(slice data, slice signature, int public_key) asm "CHKSI
 (int, int, int, int) compute_data_size?(cell c, int max_cells) asm "CDATASIZEQ NULLSWAPIFNOT2 NULLSWAPIFNOT";
 
 ;;; A non-quiet version of [slice_compute_data_size?] that throws a cell overflow exception (8) on failure.
-(int, int, int, int) slice_compute_data_size?(slice s, int max_cells) asm "SDATASIZEQ NULLSWAPIFNOT2 NULLSWAPIFNOT";
+(int, int, int, int) slice_compute_data_size?(cell c, int max_cells) asm "SDATASIZEQ NULLSWAPIFNOT2 NULLSWAPIFNOT";
 
 ;;; Throws an exception with exit_code excno if cond is not 0 (commented since implemented in compilator)
 ;; () throw_if(int excno, int cond) impure asm "THROWARGIF";


### PR DESCRIPTION
Reverts ton-org/blueprint#336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected parameter type in a standard library utility function to improve data computation functionality and API consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->